### PR TITLE
Environment variable keys  can now be separated by any user defined s…

### DIFF
--- a/conflagration/wrap.py
+++ b/conflagration/wrap.py
@@ -19,18 +19,24 @@ def config_file(file, raise_conflicts=False):
     return ret
 
 
-def environment(prefix='env.'):
+def environment(prefix, separator):
+    """Returns a dictionary of all relavent environment variables and their
+    values, with the prefix stripped from the keys."""
     env_vars = os.environ
     filtered_vars = {
         k: v for k, v in env_vars.iteritems() if k.startswith(prefix)
     }
     fdict = {}
     for k, v in filtered_vars.iteritems():
-        _keysplit = k.split(prefix)
+        _keysplit = k.split("{}{}".format(prefix, separator))
         new_key = None
         if len(_keysplit) > 1:
             new_key = _keysplit[1]
         elif len(_keysplit) == 1:
             new_key = _keysplit[0]
+        # The rest of the codebase expects the separator to be a dot, but env
+        # vars can't have dots in the name.
+        new_key = new_key.replace(separator, ".")
         fdict[new_key] = filtered_vars[k]
+
     return fdict

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,13 +8,6 @@ class Fixture(unittest.TestCase):
 
 class Test_parse_dirs(Fixture):
 
-    # @mock.patch('api.wrap')
-    # @mock.patch('api._parse_dirs')
-    # @mock.patch('api._generate_filedict')
-    # @mock.patch('api._build_super_namedtuple')
-    # def test_conflagration_defaults(self, mbsnt, mgf, mpf, mw):
-    #     r = conflagration()
-
     def test_parse_dirs_returns_empty_list_on_empty_dir_list(self):
         r = api._parse_dirs([])
         self.assertIsInstance(r, list)
@@ -70,9 +63,15 @@ class Test_parse_dirs(Fixture):
         mdtnd.return_value = 'VALUE1'
         mdtn.return_value = 'VALUE2'
         r = api._build_super_namedtuple(inputd, 'name')
+
         self.assertEqual(r, 'VALUE2')
-        mdtnd.assert_called_once_with(dict(), ['key', 'subkey'], 'VALUE0')
-        mdtn.assert_called_once_with(dict(), 'name')
+
+        mdtnd.assert_called_once_with(
+            return_dict=dict(),
+            splitkey_list=['key', 'subkey'],
+            value='VALUE0')
+
+        mdtn.assert_called_once_with(source_dict=dict(), name='name')
 
     @mock.patch("conflagration.api.os.walk")
     def test_parse_dirs_returns_file_list_for_multiple_dirs(self, mockwalk):


### PR DESCRIPTION
…tring, and default to a double underscore '__'