### PR TITLE
Moved relevant config and env parsing logic from api.py into wrap.py

### DIFF
--- a/conflagration/namespace.py
+++ b/conflagration/namespace.py
@@ -1,0 +1,71 @@
+try:
+    # Python 3
+    from types import SimpleNamespace as _Namespace
+except ImportError:
+    # Python 2.x fallback
+    from argparse import Namespace as _Namespace
+
+
+class _NamespaceDict(_Namespace):
+    def __getitem__(self, item):
+        return self.__dict__[item]
+
+
+def namespace_hook(d):
+    """Corrects an issue where keys named 'self' cause this to error."""
+    if 'self' in d.keys():
+        d['self_'] = d['self']
+        del d['self']
+    return _NamespaceDict(**d)
+
+
+# ############Code below here is experimental ##############
+# Global registry of all namspace modifiers
+modifiers = _NamespaceDict()
+
+
+class _ModifierRegistrar(type):
+
+    def __new__(cls, clsname, bases, attrs):
+        modclass = super(_ModifierRegistrar, cls).__new__(
+            cls, clsname, bases, attrs)
+        global modifiers
+        modifiers.__dict__[clsname] = modclass
+        return modclass
+
+
+class KeyMapper(object):
+    __metaclass__ = _ModifierRegistrar
+    """Given key_remapping_dict, replaces all keys in original_dict with the
+    value of the corresponding key in key_remapping_dict.
+    By default, it will also remap self to self_ to prevent issues with the
+    NamespaceDict object.
+    """
+
+    def __init__(self, key_remapping_dict=None):
+        self.key_remapping_dict = key_remapping_dict or dict()
+
+    def __call__(self, original_dict):
+        for k in self.key_remapping_dict.keys():
+            if k in original_dict:
+                original_dict[self.key_remapping_dict[k]] = original_dict[k]
+                del original_dict[k]
+
+
+def namespace(original_dict, modifier=None):
+    """
+    TODO: This won't work if fed into json's object hook, so it can't be used
+    in place of the NamespaceDict directly yet.
+
+    Factory method for generating namespace objects.
+    Optionally allowes for providing a modifer function to act of the
+    original_dict before being turned into a namespace object.
+    """
+    if modifier:
+        modifier(original_dict)
+
+    # Apply default 'self' modification in case user provided modifer doesn't.
+    if 'self' in original_dict:
+        modifiers.KeyMapper({'self': 'self_'})(original_dict)
+
+    return _NamespaceDict(**original_dict)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,37 +41,11 @@ class Test_parse_dirs(Fixture):
             test_dict, ['key'], 'value1')
         self.assertEqual(expected, r)
 
-    @mock.patch("conflagration.api.namedtuple")
-    def test_dict_to_nt_flat_dict(self, mnt):
-        mnt.return_value = dict
-        data = {'key': 'value'}
-        r = api._dict_to_nt(data, 'name')
-        self.assertEqual(data, r)
-
-
-    @mock.patch("conflagration.api.namedtuple")
-    def test_dict_to_nt_nested_dict(self, mnt):
-        mnt.return_value = dict
-        data = {'key': {'subkey':'value'}}
-        r = api._dict_to_nt(data, 'name')
-        self.assertEqual(data, r)
-
-    @mock.patch("conflagration.api._dict_to_nt")
-    @mock.patch("conflagration.api._dotstring_to_nested_dict")
-    def test_build_super_namedtuple(self, mdtnd, mdtn):
-        inputd = {'key.subkey':'VALUE0'}
-        mdtnd.return_value = 'VALUE1'
-        mdtn.return_value = 'VALUE2'
-        r = api._build_super_namedtuple(inputd, 'name')
-
-        self.assertEqual(r, 'VALUE2')
-
-        mdtnd.assert_called_once_with(
-            return_dict=dict(),
-            splitkey_list=['key', 'subkey'],
-            value='VALUE0')
-
-        mdtn.assert_called_once_with(source_dict=dict(), name='name')
+    def test_build_namespace(self):
+        address_dict = {'key.subkey':'VALUE0'}
+        separator="."
+        r = api._build_namespace(address_dict, separator)
+        self.assertEqual(r.key.subkey, "VALUE0" )
 
     @mock.patch("conflagration.api.os.walk")
     def test_parse_dirs_returns_file_list_for_multiple_dirs(self, mockwalk):


### PR DESCRIPTION
Moved relevant config and env parsing logic from api.py into wrap.py
created Env and ConfigFile classes to wrap respective parsing logic.
Added feature to write a conflagration to a file as a config file.
Added feature to write a conflagration to a file as a series of bash export commands.
Raise conflicts flag should work now.
Env var prefix and separator keywords should work now.
Files is an optional keyword now (for defaulting the conflagration to the env when no files are present).
added namespace.py
Uses NamespaceDict object in namespace.py instead of NamedTuple.
Added experimental support for NamespaceDict instantiation modifiers.